### PR TITLE
Added modifiable request timeout

### DIFF
--- a/pkg/handlers/subscription_handler.go
+++ b/pkg/handlers/subscription_handler.go
@@ -310,7 +310,11 @@ func (w *webhookResponseWrapper) WriteHeader(status int) {
 
 // New returns new handler
 func New(cfg Config) *Handler {
-	rt, _ := router.NewRouter(cfg.RouterConfig)
+	var requestTimeout int64
+	if requestTimeout = cfg.RouterConfig.RequestTimeout; cfg.RouterConfig.RequestTimeout <= 0 {
+		requestTimeout =
+			int64(^uint(0) >> 1)
+	}
 	h := Handler{
 		Schema:   cfg.Schema,
 		graphiql: cfg.GraphiQL,
@@ -321,7 +325,7 @@ func New(cfg Config) *Handler {
 			EnableCompression: true,
 		},
 		rootObjectFn:   cfg.RootObjectFn,
-		requestTimeout: rt.RequestTimeout,
+		requestTimeout: time.Duration(requestTimeout),
 	}
 	if cfg.CheckOrigin != nil {
 		h.upgrader.CheckOrigin = cfg.CheckOrigin

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -116,6 +116,7 @@ type Config struct {
 	SubscriptionConfigs map[string]SubscriptionConfig `json:"subscriptionConfigs"` // Configure subscription behaviour per field
 	MaxDepth            int                           `json:"maxDepth,omitempty"`
 	Authorize           *AuthorizeConfig              `json:"authorize,omitempty"` // Authorize configures optional authorization function before any resolver is ran
+	RequestTimeout      int64                         `json:"requestTimeout,omitempty"`
 }
 
 // AddResolver creates a new resolver mapping in config

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"github.com/graphql-editor/stucco/pkg/driver"
 	"github.com/graphql-editor/stucco/pkg/parser"
@@ -23,6 +24,7 @@ type Router struct {
 	Subscriptions       SubscriptionConfig            // global subscription config
 	SubscriptionConfigs map[string]SubscriptionConfig // subscription config per subscription field
 	MaxDepth            int                           // allow limiting max depth of GraphQL recursion
+	RequestTimeout      time.Duration
 }
 
 func (r *Router) bindInterfaces(c *parser.Config) error {
@@ -261,12 +263,13 @@ func (r *Router) load(c Config) error {
 func NewRouter(c Config) (Router, error) {
 	c.Environment.Merge(DefaultEnvironment())
 	r := Router{
-		Interfaces:    make(map[string]InterfaceConfig, len(c.Interfaces)),
-		Resolvers:     make(map[string]ResolverConfig, len(c.Resolvers)),
-		Scalars:       make(map[string]ScalarConfig, len(c.Scalars)),
-		Unions:        make(map[string]UnionConfig, len(c.Unions)),
-		Subscriptions: c.Subscriptions,
-		MaxDepth:      c.MaxDepth,
+		Interfaces:     make(map[string]InterfaceConfig, len(c.Interfaces)),
+		Resolvers:      make(map[string]ResolverConfig, len(c.Resolvers)),
+		Scalars:        make(map[string]ScalarConfig, len(c.Scalars)),
+		Unions:         make(map[string]UnionConfig, len(c.Unions)),
+		Subscriptions:  c.Subscriptions,
+		MaxDepth:       c.MaxDepth,
+		RequestTimeout: time.Duration(c.RequestTimeout),
 	}
 	err := r.load(c)
 	return r, err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -277,9 +277,10 @@ func New(c Config) (httpHandler http.Handler, err error) {
 	}
 	if err == nil {
 		httpHandler = handlers.WithProtocolInContext(gqlhandler.New(gqlhandler.Config{
-			Schema:   &rt.Schema,
-			Pretty:   checkPointerBoolDefaultTrue(c.Pretty),
-			GraphiQL: checkPointerBoolDefaultTrue(c.GraphiQL),
+			RouterConfig: c.Config,
+			Schema:       &rt.Schema,
+			Pretty:       checkPointerBoolDefaultTrue(c.Pretty),
+			GraphiQL:     checkPointerBoolDefaultTrue(c.GraphiQL),
 		}))
 	}
 	return


### PR DESCRIPTION
Added a modifiable request timeout that cancels the request beyond the set time. it can be added in the stucco.json file, timeout must be integer value:

`{
  "requestTimeout": timeout,
  "resolvers": {
    "Human.friends": {
      "resolve": {
        "name": "function.friends"
      }
    },
    [...]
}`